### PR TITLE
fix: updateProfile 중 accountname 동일하면 validation 검사 하지 않기

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -123,17 +123,21 @@ export class UserService {
 		if (!accountname || !username) {
 			throw new HttpException('필수 입력사항을 입력해주세요.', HttpStatus.BAD_REQUEST);
 		}
-		const isAccountNameExist = await this.userModel.exists({ accountname });
-		if (isAccountNameExist) {
-			throw new HttpException('이미 가입된 계정ID 입니다.', HttpStatus.BAD_REQUEST);
-		}
 
 		const user = await this.getUserById(_id);
+		if (user.accountname !== accountname) {
+			const isAccountNameExist = await this.userModel.exists({ accountname });
+			if (isAccountNameExist) {
+				throw new HttpException('이미 가입된 계정ID 입니다.', HttpStatus.BAD_REQUEST);
+			}
+		}
+
 		user.username = username;
 		user.accountname = accountname;
 		user.intro = intro;
 		user.image = image;
 
+		console.log(user);
 		await user.save();
 
 		return {


### PR DESCRIPTION
## Summary
profileUpdate 시 accountname이 동일해도 validation 검사로 400 ERROR 리턴하는 부분
BE에서 이중 검증 해주는 것으로 수정

## ref
Issue #26 