### PR TITLE
search error (없는 키워드)

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -157,7 +157,7 @@ export class UserService {
 			.lean()
 			.exec();
 		if (!users || users.length === 0) {
-			throw new HttpException('검색한 유저 정보가 없습니다.', HttpStatus.NOT_FOUND);
+			return [];
 		}
 		const newUsers = users
 			.filter(user => user._id !== userId)


### PR DESCRIPTION
## Summary
검색한 키워드로 된 결과물이 없는경우 에러 발생 수정

## Details
키워드로 검색한 결과물이 없는 경우 
`throw new HttpException('검색한 유저 정보가 없습니다.', HttpStatus.NOT_FOUND);`로 404 에러를 리턴해서 오류가 생겼었음
빈 배열을 리턴하는걸로 수정함

## ref

close #38 
