### PR TITLE
POST /accountnamevalid 에서 중복된 계정 이름 오류

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -41,10 +41,11 @@ export class UserController {
 
 	@Post('/accountnamevalid')
 	@Header('content-type', 'application/json')
+	@UseGuards(JwtAuthGuard)
 	@HandleErrors()
-	async validateAccountName(@Body() user: AccountNameValidRequestDto) {
+	async validateAccountName(@Req() req, @Body() user: AccountNameValidRequestDto) {
 		const { accountname } = user.user;
-		return await this.userService.validateAccountName(accountname);
+		return await this.userService.validateAccountName(req.user._id, accountname);
 	}
 
 	@Put()

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -90,10 +90,13 @@ export class UserService {
 		return { message: '사용 가능한 이메일 입니다.' };
 	}
 
-	async validateAccountName(accountname: string) {
-		const isAccountNameExist = await this.userModel.exists({ accountname });
-		if (isAccountNameExist) {
-			throw new HttpException('이미 가입된 계정ID 입니다.', HttpStatus.BAD_REQUEST);
+	async validateAccountName(_id: string, accountname: string) {
+		const myInfo = await this.getUserById(_id);
+		if (myInfo.accountname !== accountname) {
+			const isAccountNameExist = await this.userModel.exists({ accountname });
+			if (isAccountNameExist) {
+				throw new HttpException('이미 가입된 계정ID 입니다.', HttpStatus.BAD_REQUEST);
+			}
 		}
 		return { message: '사용 가능한 계정ID 입니다.' };
 	}


### PR DESCRIPTION
## Summary

<!-- 요약 -->
accountname 을 수정했다가 다시 원래대로 만들었을 경우
POST /accountnamevalid 에서 중복된 계정 이름이라고 나오는 오류

## Details

<!-- 자세한 기능별 내용 -->
accountnamevalid에서 myInfo의 accountname과 비교하는 부분을 추가

## ISSUE
API 요청시 Header에 JWT 토큰을 보내주지 않는다는 사실 확인
-> 업데이트 보류