### PR TITLE
self search issue

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -167,7 +167,7 @@ export class UserService {
 			return [];
 		}
 		const newUsers = users
-			.filter(user => user._id !== userId)
+			.filter(user => user._id.toString() !== userId)
 			.map(user => {
 				return {
 					...user,


### PR DESCRIPTION
## Summary

자기자신은 검색 리스트에서 제외

## Details

유저검색시 자기 자신 검색되는걸 없앴습니다.
키워드로 db에서 조회해온 users 데이터배열을 돌며 userId와 비교하는데 
user._id에 `toString()`을 안붙이면 `new ObjectId('어쩌구저쩌구_id값')`이렇게 돼서 id값끼리 비교가 되지 않고 있었습니다
```
const newUsers = users
	.filter(user => user._id.toString() !== userId)
	.map(user => {
		return {
			...user,
			followerCount: user.follower.length,
			followingCount: user.following.length,
		};
	});
```


