### PR TITLE
HOTFIX: 이미지 삭제 파일 이름 수정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+lion-api의 모든 변경사항을 이 파일에 기록합니다.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [1.1.1rc0] - 2024-08-15
+
+### Fixed
+
+- image 삭제 기능 수정
+  - `process.env.API_HOST` 시작하는 이미지 파일만 삭제
+  - 이전 로컬 기본 이미지까지 삭제하려고 했던 문제 수정

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lion-api",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "멋쟁이 사자처럼 BackEnd API",
 	"author": "hyeri-woo, doha-lee, dasom-Im, charlie-kim",
 	"private": false,

--- a/src/image/image.service.ts
+++ b/src/image/image.service.ts
@@ -1,11 +1,11 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
-import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
-import { Image, ImageDocument } from './image.schema';
-import * as fs from 'fs';
-import * as path from 'path';
 import { imageDTO } from '@image/image.dto';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
 import { imageUnlink } from '@util/imageUnlink';
+import * as fs from 'fs';
+import { Model } from 'mongoose';
+import * as path from 'path';
+import { Image, ImageDocument } from './image.schema';
 
 @Injectable()
 export class ImageService {
@@ -63,16 +63,18 @@ export class ImageService {
 		}
 
 		let filenameArr = [];
-		if (filename.startsWith('http://') || filename.startsWith('https://')) {
+		if (filename.startsWith(process.env.API_HOST)) {
 			const url = new URL(filename);
 			filenameArr.push(path.basename(url.pathname));
 		} else {
 			filenameArr = filename.split(',').map(file => file.trim());
 		}
 
-		for (const file of filenameArr) {
-			await this.imageModel.deleteOne({ filename: file });
-			imageUnlink(file);
+		if (filename.startsWith(process.env.API_HOST)) {
+			for (const file of filenameArr) {
+				await this.imageModel.deleteOne({ filename: file });
+				imageUnlink(file);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

<!-- 요약 -->

- 이미지 삭제 파일 이름 수정

## Details

<!-- 자세한 기능별 내용 -->

- `http`, `https`로 시작하는 이미지는 모두 삭제 했으나 로컬에 있는 기본 이미지가 서버에 없어서 에러를 뿜음
 -  `process.env.API_HOST`로 시작하는 이미지만 삭제되게 변경 

## ref

<!-- 예시: close #26   -->
<!-- close 키워드를 붙여주면 merge되면 해당 이슈도 자동으로 닫힘 -->

close #44 
